### PR TITLE
METRO 422: update saaj-ri maven plugin version to support latest jdk9 

### DIFF
--- a/saaj-ri/pom.xml
+++ b/saaj-ri/pom.xml
@@ -111,7 +111,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/saaj-ri/pom.xml
+++ b/saaj-ri/pom.xml
@@ -96,7 +96,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.20</version>
+                    <configuration>
+                        <forkCount>1</forkCount>
+                        <reuseForks>false</reuseForks>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -289,7 +293,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.4</version>
+                        <version>3.0.0-M1</version>
                     </plugin>
                 </plugins>
             </build>
@@ -349,7 +353,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
+                        <version>2.20</version>
                         <configuration>
                             <argLine>${proxyOpts} -Djdk.build=true</argLine>
                             <!-- some random non-existing directory to make sure the built classes are not found, instead the ones from jdk are used -->
@@ -381,7 +385,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.16</version>
+                        <version>2.20</version>
                         <configuration>
                             <argLine>${proxyOpts} -Djdk.build=true -Djava.security.manager -Djava.security.policy=./src/test/test.policy</argLine>
                             <!-- some random non-existing directory to make sure the built classes are not found, instead the ones from jdk are used -->


### PR DESCRIPTION
As saaj-ri build failed with jdk9-169 or above, there are some exceptions for maven-javadoc-plugin, so upgrade plugin version from 2.10.4 to latest 3.0.0-M1
@bravehorsie @lukasj @Xiaojwu @yuHe1 @zhengjl