### PR TITLE
code at c.s.x.i.m.saaj.soap.MessageImpl must be modified to 

### DIFF
--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/MessageImpl.java
@@ -905,7 +905,7 @@ public abstract class MessageImpl
         needsSave();
     }
 
-    static private final Iterator<AttachmentPart> nullIter = Collections.<AttachmentPart>EMPTY_LIST.iterator();
+    static private final Iterator<AttachmentPart> nullIter = Collections.EMPTY_LIST.<AttachmentPart>iterator();
 
     @Override
     public Iterator<AttachmentPart> getAttachments() {


### PR DESCRIPTION
The change was to fix bug [JDK-8186314] code at c.s.x.i.m.saaj.soap.MessageImpl must be modified to avoid crash after javac change.
https://bugs.openjdk.java.net/browse/JDK-8186314

@lukasj @bravehorsie @m0mus @HOHOWU @Xiaojwu @yuHe1 