### PR TITLE
 Updated dependencies in pom.xml. Fixed javadoc errors. 

### DIFF
--- a/saaj-ri/pom.xml
+++ b/saaj-ri/pom.xml
@@ -474,17 +474,17 @@
             <dependency>
                 <groupId>org.jvnet.mimepull</groupId>
                 <artifactId>mimepull</artifactId>
-                <version>1.9.7</version>
+                <version>1.9.8</version>
             </dependency>
             <dependency>
                 <groupId>org.jvnet.staxex</groupId>
                 <artifactId>stax-ex</artifactId>
-                <version>1.7.8</version>
+                <version>1.8</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>3.8.2</version>
+                <version>4.12</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/saaj-ri/pom.xml
+++ b/saaj-ri/pom.xml
@@ -2,7 +2,7 @@
 
     DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-    Copyright (c) 2011-2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011-2018 Oracle and/or its affiliates. All rights reserved.
 
     The contents of this file are subject to the terms of either the GNU
     General Public License Version 2 only ("GPL") or the Common Development
@@ -54,12 +54,14 @@
     <description>
         Open source Reference Implementation of JSR-67: SOAP with Attachments API for Java (SAAJ MR: 1.4)
     </description>
+
     <scm>
         <connection>scm:git:git@github.com:javaee/metro-saaj.git</connection>
         <developerConnection>scm:git:git@github.com:javaee/metro-saaj.git</developerConnection>
         <url>https://github.com/javaee/metro-saaj</url>
         <tag>HEAD</tag>
     </scm>
+
     <build>
         <sourceDirectory>src/java</sourceDirectory>
         <testSourceDirectory>src/test</testSourceDirectory>
@@ -76,7 +78,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.1</version>
+                    <version>3.7.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -86,17 +88,17 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.42</version>
+                    <version>1.49</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.0.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.20.1</version>
                     <configuration>
                         <forkCount>1</forkCount>
                         <reuseForks>false</reuseForks>
@@ -115,7 +117,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -293,7 +295,21 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.0-M1</version>
+                        <version>3.0.0</version>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -353,7 +369,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.20</version>
+                        <version>2.20.1</version>
                         <configuration>
                             <argLine>${proxyOpts} -Djdk.build=true</argLine>
                             <!-- some random non-existing directory to make sure the built classes are not found, instead the ones from jdk are used -->
@@ -385,7 +401,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.20</version>
+                        <version>2.20.1</version>
                         <configuration>
                             <argLine>${proxyOpts} -Djdk.build=true -Djava.security.manager -Djava.security.policy=./src/test/test.policy</argLine>
                             <!-- some random non-existing directory to make sure the built classes are not found, instead the ones from jdk are used -->
@@ -411,10 +427,25 @@
         <name>Oracle</name>
         <url>http://www.oracle.com/</url>
     </organization>
+
+    <developers>
+        <developer>
+            <id>bravehorsie</id>
+            <name>Roman Grigoriadi</name>
+            <email>Roman.Grigoriadi@oracle.com</email>
+        </developer>
+        <developer>
+            <id>lukasj</id>
+            <name>Lukas Jungmann</name>
+            <email>Lukas.Jungmann@oracle.com</email>
+        </developer>
+    </developers>
+
     <issueManagement>
         <system>IssueTracker</system>
         <url>https://github.com/javaee/metro-saaj/issues</url>
     </issueManagement>
+
     <mailingLists>
         <mailingList>
             <name>Metro mailing list</name>
@@ -423,6 +454,7 @@
             <archive>https://javaee.groups.io/g/metro/topics</archive>
         </mailingList>
     </mailingLists>
+
     <licenses>
       <license>
         <name>CDDL + GPLv2 with classpath exception</name>

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/SOAPDocumentImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/SOAPDocumentImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 1997-2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -599,8 +599,6 @@ public class SOAPDocumentImpl implements SOAPDocument, javax.xml.soap.Node, Docu
      *
      * @param node w3c dom node nullable
      * @return soap wrapper for w3c dom node
-     *
-     * @throws
      */
     public javax.xml.soap.Node find(Node node) {
         return find(node, true);

--- a/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/TextImpl.java
+++ b/saaj-ri/src/java/com/sun/xml/messaging/saaj/soap/impl/TextImpl.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017-2018 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -57,7 +57,7 @@ import org.w3c.dom.UserDataHandler;
 /**
  *
  * @author lukas
- * @param <T>
+ * @param <T> node type
  */
 public abstract class TextImpl<T extends CharacterData> implements Text, CharacterData {
 


### PR DESCRIPTION
SAAJ now depends on stax-ex to 1.8 and mimepull to 1.9.8 which are in staging repository. This may temporary break the build until both components are released into maven central.
But SAAJ release shall depend on latest components.